### PR TITLE
Fixed 3 issues of type: PYTHON_E302 throughout 1 file in repo.

### DIFF
--- a/DownloadImages.py
+++ b/DownloadImages.py
@@ -1,6 +1,7 @@
 import os
 import multiprocessing
 
+
 def ExtractUrls(txt):
     pos1=0
     pos2=-6
@@ -17,8 +18,12 @@ def ExtractUrls(txt):
         pos2 = line.index("\"ow\"")
         urls.append(line[pos1+6:pos2-2])
     return urls
+
+
 def Download(name, url):
     os.system('wget -O %s -T 10 -t 3 %s' % (name, url))
+
+
 def MultiRunWrapper(args):
     return Download(*args) 
 


### PR DESCRIPTION
PYTHON_E302: 'expected 2 blank lines, found 0'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.