### PR TITLE
Fixed 1 issue of type: PYTHON_W291 throughout 1 file in repo.

### DIFF
--- a/DownloadImages.py
+++ b/DownloadImages.py
@@ -20,7 +20,7 @@ def ExtractUrls(txt):
 def Download(name, url):
     os.system('wget -O %s -T 10 -t 3 %s' % (name, url))
 def MultiRunWrapper(args):
-    return Download(*args) 
+    return Download(*args)
 
 if __name__ == '__main__':
     rootDir = 'urls-30w-357488/'


### PR DESCRIPTION
PYTHON_W291: 'Remove trailing whitespace.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.